### PR TITLE
Add support for versioned loadrunner.js files. Versions are Pro Style™

### DIFF
--- a/src/loadrunner.js
+++ b/src/loadrunner.js
@@ -5,10 +5,11 @@
       scriptsInProgress = {}, modulesInProgress = {}, loadedModule,
       currentScript, activeScripts = {}, oldUsing = context.using,
       oldProvide = context.provide, oldDefine = context.define,
-      oldLoadrunner = context.loadrunner;
+      oldLoadrunner = context.loadrunner,
+      loadRunnerFileRegex = /loadrunner([v0-9\.-]+)?\.js(\?|#|$)/;
 
   for (var i=0, s; s = scripts[i]; i++) {
-    if (s.src.match(/loadrunner\.js(\?|#|$)/)) {
+    if (s.src.match(loadRunnerFileRegex)) {
       scriptTag = s;
       break;
     }
@@ -515,6 +516,7 @@
   context.define  = amdDefine;
 
   using.path = '';
+  using.loadRunnerFileRegex = loadRunnerFileRegex;
 
   using.matchers = [];
   using.matchers.add = function(regex, factory) {
@@ -544,7 +546,7 @@
   }
 
   if (scriptTag) {
-    using.path = scriptTag.getAttribute('data-path') || scriptTag.src.split(/loadrunner\.js/)[0] || '';
+    using.path = scriptTag.getAttribute('data-path') || scriptTag.src.split(loadRunnerFileRegex)[0] || '';
 
     if (main = scriptTag.getAttribute('data-main')) {
       using.apply(context, main.split(/\s*,\s*/)).then(function() {});

--- a/test/test.html
+++ b/test/test.html
@@ -26,6 +26,13 @@
            ok(mainLoaded, 'main should be loaded');
          });
 
+         QUnit.test('should be able to version the loadrunner.js file', function() {
+           ok('loadrunner.js'.match(using.loadRunnerFileRegex), 'unversioned allowed');
+           ok('loadrunner-20110630.js'.match(using.loadRunnerFileRegex), 'dated version allowed');
+           ok('loadrunner-1.0.0.js'.match(using.loadRunnerFileRegex), 'numeric version allowed');
+           ok('loadrunner-v1.0.0.js'.match(using.loadRunnerFileRegex), 'numeric version with v allowed');
+         });
+
          QUnit.module('module');
 
          QUnit.test('should be able to define a module with an object literal', function() {
@@ -389,7 +396,6 @@
               start();
             });
           });
-
 
 
      }


### PR DESCRIPTION
I found out that versioned loadrunner.js files disable `data-path` and `data-main` because of a restrictive regex. Added support and a test for it.
