### PR TITLE
Throw an error when module requested, script loaded, but module not provided

### DIFF
--- a/src/loadrunner.js
+++ b/src/loadrunner.js
@@ -240,6 +240,9 @@
     if (!useInteractive) {
       module = loadedModule;
       loadedModule = null;
+      if (!module) {
+        throw new Error('Module "'+this.id+'" requested but no module "'+this.id+'" provided by script at '+this.path);
+      }
       module.id = module.id || this.id;
 
       module.then(function(exports) {


### PR DESCRIPTION
Hi,
I ran into an issue while using loadrunner to convert some of my code to modules; I had a line something like this:

```
provide('foo/events', function(exports){
  using('foo/init', 'underscore', 'jquery', 'showdown', function(){
    exports({});
  });
});
```

I was getting an error ar line 244, "Uncaught TypeError: Cannot read property 'id' of null", because module was null.  This was because, while loadrunner could load the scripts underscore.js, jquery.js, and showdown.js, they did not provide modules.

This change simply throws a more meaningful error if a programmer new to loadrunner.js is making this kind of mistake.

Let me know if you have any questions.

-Elijah
