### PR TITLE
fix amd tests

### DIFF
--- a/plugins/amd.js
+++ b/plugins/amd.js
@@ -69,19 +69,19 @@
       factory = args.shift();
 
       var def = new loadrunner.Definition(id, function(exports) {
-        var mods = [], thisDef = this;
+        var mods = [];
 
         function executeAMD() {
-          var args = mapArgs(makeArray(dependencies), thisDef), exported;
+          var args = mapArgs(makeArray(dependencies), def), exported;
 
           if (typeof factory == 'function') {
-            exported = factory.apply(thisDef, args);
+            exported = factory.apply(def, args);
           } else {
             exported = factory;
           }
 
           if (typeof exported == 'undefined') {
-            exported = thisDef.exports;
+            exported = def.exports;
           }
 
           exports(exported);
@@ -90,7 +90,7 @@
         for (var i=0, len=dependencies.length; i < len; i++) {
           var d = dependencies[i];
           if (indexOf(['require', 'exports', 'module'], d) == -1) {
-            mods.push(resolve(d, thisDef));
+            mods.push(resolve(d, def));
           }
         }
 


### PR DESCRIPTION
Not sure why this change was made in the first place, but this reverts context to get amd passing again
