### PR TITLE
AMD plugin fix

### DIFF
--- a/plugins/amd.js
+++ b/plugins/amd.js
@@ -69,19 +69,20 @@
       factory = args.shift();
 
       var def = new loadrunner.Definition(id, function(exports) {
-        var mods = [], thisDef = this;
+        var mods = [],
+            definition = exports.definition;
 
         function executeAMD() {
-          var args = mapArgs(makeArray(dependencies), thisDef), exported;
+          var args = mapArgs(makeArray(dependencies), definition), exported;
 
           if (typeof factory == 'function') {
-            exported = factory.apply(thisDef, args);
+            exported = factory.apply(definition, args);
           } else {
             exported = factory;
           }
 
           if (typeof exported == 'undefined') {
-            exported = thisDef.exports;
+            exported = definition.exports;
           }
 
           exports(exported);
@@ -90,7 +91,7 @@
         for (var i=0, len=dependencies.length; i < len; i++) {
           var d = dependencies[i];
           if (indexOf(['require', 'exports', 'module'], d) == -1) {
-            mods.push(resolve(d, thisDef));
+            mods.push(resolve(d, definition));
           }
         }
 

--- a/src/loadrunner.js
+++ b/src/loadrunner.js
@@ -358,14 +358,19 @@
     Definition.provided[id] = this;
   }
   Definition.prototype.fetch = function() {
-    var me = this;
+    var me = this,
+        complete;
 
     if (typeof this.body == 'object') {
       this.complete(this.body);
     } else if (typeof this.body == 'function') {
-      this.body.call(window, function(exports) {
+      complete = function(exports) {
         me.complete(exports);
-      });
+      };
+      // Pass a reference to this Definition instance.
+      // Used by amd.js during the Definition construction.
+      complete.definition = this;
+      this.body.call(window, complete);
     }
   }
   Definition.prototype.complete = function(exports) {


### PR DESCRIPTION
Assign a reference to the definition to the callback, to allow the AMD plugin to load relative paths properly.

We found that the AMD plugin tried to use a reference to the dependency instance.
Like so:

```
var def = new Loadrunner.Definition(id, function(exports) {
  alert(def);
}); 
```

Since the definition body can be called during construction, 'def' is not yet defined.
To alleviate the problem, we added a reference to the definition as a property on the 'exports' function:

```
var def = new Loadrunner.Definition(id, function(exports) {
  alert(exports.definition);
}); 
```

This passes the tests and works with our existing code.
