### PR TITLE
Switch context of module execution from window to the module definition.

### DIFF
--- a/src/loadrunner.js
+++ b/src/loadrunner.js
@@ -363,7 +363,7 @@
     if (typeof this.body == 'object') {
       this.complete(this.body);
     } else if (typeof this.body == 'function') {
-      this.body.call(window, function(exports) {
+      this.body(function(exports) {
         me.complete(exports);
       });
     }


### PR DESCRIPTION
This should fix the AMD references.

Module code will now execute with 'this' as the module definition, instead of 'window'.

This caused trouble with our previous codebase, where we used external libraries expecting this to be window, but should be a problem in newer codebases.
