### PR TITLE
Glaring script bundle error

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
     "name": "loadrunner",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Simple, flexible and sane JavaScript loader and build tool for browsers.",
     "contributors": [{ "name": "Dan Webb", "email": "dan@danwebb.net" }],
     "homepage": "https://github.com/danwrong/loadrunner",


### PR DESCRIPTION
Slight error made about 8 months ago - the Script.prototype.start was overwritten by the later Script.prototype = new Dependency;

This meant that loading a Script would not trigger a bundle load - existing pages work because bundles are loaded by modules first.

Fixed now, and tweaked so it actually works. Tested against our scripts.