### PR TITLE
attached amd object with define

### DIFF
--- a/plugins/amd.js
+++ b/plugins/amd.js
@@ -117,6 +117,8 @@
       return def;
     }
 
+    define.amd = {};
+
     context.define = define;
   });
 }(this));


### PR DESCRIPTION
attached amd object with define, since this plugin was unable to load jquery as module.
