### PR TITLE
Fix bundle loading for deferred scripts

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
     "name": "loadrunner",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Simple, flexible and sane JavaScript loader and build tool for browsers.",
     "contributors": [{ "name": "Dan Webb", "email": "dan@danwebb.net" }],
     "homepage": "https://github.com/danwrong/loadrunner",

--- a/test/deferred_test.html
+++ b/test/deferred_test.html
@@ -45,6 +45,32 @@
           });
         });
       });
+
+      test('should be able load deferred scripts from a bundle', function() {
+        expect(2);
+        stop(2000);
+        loadrunner.reset();
+        window.bundleLoadedThing = false;
+        window.bundleLoadedAnother = false;
+        using.bundles.push({ 'javascripts/deferred_bundle.js': ['bundled_thing.js', 'bundled_another.js'] });
+        using('bundled_thing.js', function() {
+          equals(true, window.bundleLoadedThing);
+          equals(false, window.bundleLoadedAnother);
+          start();
+        });
+      });
+
+      test('should be able load modpath deferred scripts from a bundle', function() {
+        expect(1);
+        stop(2000);
+        loadrunner.reset();
+        window.bundleLoadedModpath = false;
+        using.bundles.push({ 'javascripts/deferred_bundle.js': ['$bundled_with_modpath.js'] });
+        using('$bundled_with_modpath.js', function() {
+          equals(true, window.bundleLoadedModpath);
+          start();
+        });
+      });
     </script>
   </body>
 </html>

--- a/test/javascripts/deferred_bundle.js
+++ b/test/javascripts/deferred_bundle.js
@@ -1,0 +1,11 @@
+deferred('bundled_thing.js', function() {
+  window.bundleLoadedThing = true;
+});
+
+deferred('bundled_another.js', function() {
+  window.bundleLoadedAnother = true;
+});
+
+deferred('$bundled_with_modpath.js', function() {
+  window.bundleLoadedModpath = true;
+});


### PR DESCRIPTION
If scripts are included in bundles, then they're not able to correctly await the bundle download. Looking at the script, the script.start function is being blown away unintentionally. Fixed up and tests added.
Thanks to @mq2thez for the report.